### PR TITLE
Fix TIMOB-16286: LiveView server not getting started for CLI 3.2.1 + SDK 3.2.1.

### DIFF
--- a/hook/lvhook.js
+++ b/hook/lvhook.js
@@ -19,7 +19,7 @@ exports.init = function(logger, config, cli) {
 
 	function doConfig(data, finished) {
 		debug('Runningbuild.[PLATFORM].config hook');
-		var r = ((simpVer(cli.version) < 321) ? data.result : data.result[0]) || {};
+		var r = ((simpVer(cli.version) < 321) ? data.result : simpVer(cli.sdk.name) < 321 ? data.result[0] : data.result[1]) || {};
 		r.flags || (r.flags = {});
 		r.flags.liveview = {
 			default: false,


### PR DESCRIPTION
The content of data.result that liveview relies on to add its hook changed depending on different CLI/SDK combo:

For CLI 3.2.0 + SDK 3.2.0 or earlier: {flags: ...}
For CLI 3.2.0 + SDK 3.2.1: null (not supported)
For CLI 3.2.1 + SDK 3.2.0: [ {flags: ...} ]
For CLI 3.2.1 + SDK 3.2.1: [ null, {flags: ...} ]

The patch fixed the hook to work against all cases.
