### PR TITLE
TIMOB-16740 Windows: LiveView server does not automatically start when launched from studio on emulator

### DIFF
--- a/hook/lvhook.js
+++ b/hook/lvhook.js
@@ -120,15 +120,23 @@ exports.init = function(logger, config, cli) {
 	});
 
 	/**
-	 * Start event/file Server
+	 * Start event/file server
 	 */
-
 	cli.addHook('build.post.compile', function(build, finished) {
-    // kill running server via fserver http api
+		// kill running server via fserver http api
+		debug('invoke kill');
 		http
 			.get('http://localhost:8324/kill', function(res){})
-			.on('error', function(e){});
+			.on('error', function(e){
+				startServer(finished);
+			})
+			.on('data', function(e){})
+			.on('end', function(e){
+				startServer(finished);
+			});
+	});
 
+	function startServer(finished) {
 		if (cli.argv.liveview) {
 			debug('Running post:build.post.compile hook');
 			var binDIR = join(__dirname, '../bin/liveview-server');
@@ -149,7 +157,7 @@ exports.init = function(logger, config, cli) {
 			});
 		}
 		finished();
-	});
+	}
 };
 
 /**

--- a/lib/fserver.js
+++ b/lib/fserver.js
@@ -180,10 +180,10 @@ FServer.start = function(opts) {
     }
 
     if (uri === '/kill') {
-      response.end('');
       fServer.close();
       evtServer.close();
       rm('-rf', PID_FILE);
+      response.end('');
       process.exit(0);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveview",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Titanium Live Realtime App Development",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
For every app launch, we tried to kill all existing servers and start a new server. On Windows, there seems to be a good timing issue that the kill request is executed after the new server is started. Thus, it kills even the active liveview session.
