### PR TITLE
TIMOB-17164 Wrapping path in quotes to handle spaces in path

### DIFF
--- a/lib/fserver.js
+++ b/lib/fserver.js
@@ -448,7 +448,7 @@ FServer.start = function(opts) {
       if (isBuilding) { return log('[LiveView]'.green, 'File changes ignored while Alloy compiling'); }
       isBuilding = true;
       log('[LiveView]'.green, 'Alloy recompile initiated for', PLATFORM);
-      exec('alloy compile '+ ALLOY_DIR +' --no-colors --config platform=' + PLATFORM, {silent: true}, function (code, error) {
+      exec('alloy compile \'' + ALLOY_DIR + '\' --no-colors --config platform=' + PLATFORM, {silent: true}, function (code, error) {
         isBuilding = false;
         if(code) { return logError('[LiveView]'.red, error); }
         evtServer.emit('change', file);


### PR DESCRIPTION
The fix is to handle the spaces in the workspace path and make sure alloy compile command will wrap the app_dir in quotes.
