### PR TITLE
[TIMOB-24485] Revert TIMOB-23664 - Skip Windows virtual adapter

### DIFF
--- a/hook/lvhook.js
+++ b/hook/lvhook.js
@@ -224,9 +224,7 @@ function getNetworkIp() {
 	for (var k in n) {
 		var inter = n[k]
 		for (var j in inter)
-			if (inter[j].family === 'IPv4' && !inter[j].internal &&
-				// skip Windows virtual adapter for Windows Phone Emulator
-				!(inter[j].mac.startsWith('00:15:5d') && k.indexOf('Windows Phone Emulator') > 0)) {
+			if (inter[j].family === 'IPv4' && !inter[j].internal) {
 				return inter[j].address
 			}
 	}


### PR DESCRIPTION
[TIMOB-24485](https://jira.appcelerator.org/browse/TIMOB-24485)

Revert #94 because this adapter may be used to communicate to emulators. From what I see on the latest Win 10 SDK & emulators this adapter is actually used. So I think under the variety of user's network configurations we should not skip specific interface automatically but should provide a way to select preferred interface to use - which is implemented in #96 ([CLI-1075](https://jira.appcelerator.org/browse/CLI-1075)).
