### PR TITLE
fix: do not log ESRCH errors when stopping liveview

### DIFF
--- a/lib/fserver.js
+++ b/lib/fserver.js
@@ -99,10 +99,14 @@ FServer.stop = function (env) {
 		try {
 			let _pid = pidPath.replace(TMP_DIR, '').split('-')[0];
 			rm(pidPath);
-			log('[LiveView]'.green, 'Closing file/event server process id: ' + _pid);
+			log('[LiveView]'.green, 'Attempting to close file/event server process id: ' + _pid);
 			process.kill(_pid);
 		} catch (e) {
-			logError('[LiveView]'.red, 'Error closing server', e);
+			// Only log the error if it's not an ESRCH (no such process) as
+			// sometimes liveview does not clean up the pidfile when stopping
+			if (e.code !== 'ESRCH') {
+				logError('[LiveView]'.red, 'Error closing server', e);
+			}
 		}
 	});
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-26267

h5.Steps to reproduce

1. Create a liveview pid file with a pid that definitely doesn't exist `touch ~/.titanium/123456789-liveview` 
2. Run `liveview server stop`

No error should be logged with this change