### PR TITLE
fix(i18n): only read in strings.xml if it exists

### DIFF
--- a/lib/fserver.js
+++ b/lib/fserver.js
@@ -255,8 +255,11 @@ FServer.start = function (opts) {
 					}
 					tags[e.attr.name] = decodeEntity(this._text);
 				});
-
-				fs.createReadStream(join(LOCALE_DIR, langs[i], 'strings.xml'))
+				const stringsPath = join(LOCALE_DIR, langs[i], 'strings.xml');
+				if (!fs.existsSync(stringsPath)) {
+					return next(i + 1);
+				}
+				fs.createReadStream(stringsPath)
 					.pipe(parser)
 					.on('data', function () {
 						langData[langs[i]] = tags;


### PR DESCRIPTION
fixes TIMOB-26649

LiveViews assumption that a strings.xml file must exist if an i18n language dir exists appears to be incorrect, so before reading the file check that it actually exists/