### PR TITLE
chore(deps): update to latest node-titanium-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liveview",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveview",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Titanium Live Realtime App Development",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This is to align with the 8.1.0 branch of the SDK. v1.5.0 of liveview should not land on the 8_0_X branch of titanium_mobile