### PR TITLE
fix: crash when localeStrings is not found

### DIFF
--- a/lib/platform/require.js
+++ b/lib/platform/require.js
@@ -88,7 +88,11 @@ Module.patch = function (globalCtx, url, port) {
 		// ignore
 	}
 
-	globalCtx.localeStrings = Module.require('localeStrings');
+	try {
+		globalCtx.localeStrings = Module.require('localeStrings');
+	} catch (e) {
+		globalCtx.localeStrings = [];
+	}
 	Module.connectServer();
 };
 
@@ -120,8 +124,9 @@ Module.connectServer = function () {
 	});
 
 	client.on('connect', function () {
-		if (retryInterval) {
+		if (retryInterval !== null) {
 			clearInterval(retryInterval);
+			retryInterval = null;
 			console.log('[LiveView]', 'Reconnected to Event Server');
 		}
 	});


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-27324

Fix crash on deploying to Windows 10 mobile device. I'm not sure why exactly `localeStrings` is needed but we should be able to keep liveview alive even when`localeStrings` is not found. This PR also fixes logical bug on reconnect where `clearInterval` is not executed when timer id equals `0`.

How to test:

```
appc run -p windows -l trace --target wp-device --liveview --liveview-ip <host ip address>
```

In case you are not sure about your host ip address, execute `console.log(JSON.stringify(require('os').networkInterfaces(), null, 2));` on Node.js.