### PR TITLE
fix: disable alloy detection when webpack is active

### DIFF
--- a/lib/fserver.js
+++ b/lib/fserver.js
@@ -171,7 +171,7 @@ FServer.start = function (opts) {
 
 	const ALLOY_DIR = join(PROJECT_DIR, 'app');
 	const LOCALE_DIR = join(PROJECT_DIR, 'i18n');
-	const isAlloy = fs.existsSync(ALLOY_DIR);
+	const isAlloy = fs.existsSync(ALLOY_DIR) && !process.env.TI_USE_WEBPACK;
 	const hasLocale = fs.existsSync(LOCALE_DIR);
 
 	const pidObj = {
@@ -309,7 +309,7 @@ FServer.start = function (opts) {
 						out.code = 200;
 						// We only want to transpile the users code/modules,
 						// transpiling the polyfill libs makes things go a bit wonky
-						if (filename !== buildNodeModulesPath) {
+						if (filename !== buildNodeModulesPath && !process.env.TI_USE_WEBPACK) {
 							const transpiled = jsanalyze.analyzeJs(file, {
 								filename: filename,
 								minify: false,


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-27907

Disables all special handling for Alloy when Webpack is active. Also disables processing with Babel, since Webpack already did that.