### PR TITLE
fix(all): exclude semantic.colors.json

### DIFF
--- a/lib/fserver.js
+++ b/lib/fserver.js
@@ -460,7 +460,11 @@ FServer.start = function (opts) {
 	 * check if alloy project folder should be watched
 	 */
 	if (isAlloy) {
-		const alloyWatcher = fsWatcher.watch(ALLOY_DIR, { persistent: true, ignoreInitial: true });
+		const alloyWatcher = fsWatcher.watch(ALLOY_DIR, {
+			persistent: true,
+			ignoreInitial: true,
+			ignored: [ /semantic\.colors\.json/ ]
+		});
 		log('[LiveView]'.green, 'Alloy project monitor started');
 
 		alloyWatcher.on('change', function (file) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liveview",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Titanium Live Realtime App Development",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Changing the JSON file will crash liveview with:

```
[ERROR] Error transforming JS file
[ERROR] /home/miga/dev/titanium/test_test/Resources/android/semantic.colors.json: Missing semicolon. (2:21)
[ERROR] 
[ERROR]   1 | {
[ERROR] > 2 |   "primaryBackground": {
[ERROR]     |                      ^
[ERROR]   3 |     "light": "#efece3",
[ERROR]   4 |     "dark": "#000000"
[ERROR]   5 |   },
[ERROR] position 23
```

This fix will ignore the file so you can continue to work even if you change a value (values aren't visible of course but it doesn't crash).