### PR TITLE
ci: use next tag for pre-releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   release:
-    types: [ created ]
+    types: [published]
 
 jobs:
   publish:
@@ -28,4 +28,5 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: npm publish
+        RELEASE_TAG: ${{ github.event.release.prerelease && 'next' || 'latest' }}
+      run: npm publish --tag $RELEASE_TAG


### PR DESCRIPTION
Here is my idea how to manage pre-release publishes. When a release is published we check the `prerelease` flag and set the tag accordingly.