### PR TITLE
fix: handle trailing comma in dynamic require optimizer

### DIFF
--- a/src/node/optimizer/scan.ts
+++ b/src/node/optimizer/scan.ts
@@ -228,7 +228,7 @@ async function transformDynamicRequire(
 			continue;
 		}
 
-		const url = source.slice(start, end);
+		const url = source.slice(start, end).replace(/,$/, '');
 		const context = await createDynamicRequireContext(url, importer, resolve);
 		if (
 			context === null ||

--- a/src/node/utils/analyzer.ts
+++ b/src/node/utils/analyzer.ts
@@ -478,7 +478,7 @@ export function parseRequires(code: string, filename = '@'): RequireInfo[] {
 				) {
 					const currentRequire = requireStack[requireStackDepth - 1];
 					if (currentRequire.end === 0) {
-						currentRequire.end = pos;
+						currentRequire.end = lastTokenPos + 1;
 					}
 					currentRequire.statementEnd = pos + 1;
 					requireStackDepth--;


### PR DESCRIPTION
Follow up fix for #234 for dynamic require edge cases. There is still something wrong with the initial require statement extraction as the trailing comma shouldn't be included there, but this will fix for now.

I will investigate this further next week to come up with a proper solution.